### PR TITLE
Enable package API with frontend

### DIFF
--- a/rideshare-frontend/src/app/send-packages/page.tsx
+++ b/rideshare-frontend/src/app/send-packages/page.tsx
@@ -1,167 +1,143 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Package } from '@/types/package';
 
-export default function TripControlPage() {
-  const [tab, setTab] = useState<'trips' | 'create' | 'requests' | 'mytrips'>('trips');
+export default function PackagesPage() {
+  const router = useRouter();
+  const [packages, setPackages] = useState<Package[]>([]);
+  const [tab, setTab] = useState<'list' | 'create'>('list');
+  const [loading, setLoading] = useState(true);
+  const [formData, setFormData] = useState({
+    recipient_name: '',
+    origin: '',
+    destination: '',
+    weight_kg: '',
+    description: '',
+    price: '',
+    date: ''
+  });
+
+  useEffect(() => {
+    fetchPackages();
+  }, []);
+
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  const fetchPackages = async () => {
+    const token = localStorage.getItem('access_token');
+    if (!token) {
+      router.push('/auth/login');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`${apiBase}/api/packages/`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      setPackages(data.results || data);
+    } catch (err) {
+      console.error('Failed to load packages', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleInput = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const token = localStorage.getItem('access_token');
+    if (!token) {
+      router.push('/auth/login');
+      return;
+    }
+    try {
+      const res = await fetch(`${apiBase}/api/packages/`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
+      });
+      if (res.ok) {
+        setFormData({ recipient_name: '', origin: '', destination: '', weight_kg: '', description: '', price: '', date: '' });
+        fetchPackages();
+        setTab('list');
+      } else {
+        const errData = await res.json();
+        console.error('Failed to create package', errData);
+      }
+    } catch (err) {
+      console.error('Failed to create package', err);
+    }
+  };
 
   return (
     <div className="p-4">
-      {/* Меню вкладок */}
       <div className="flex justify-center gap-8 border-b pb-3 text-sm font-medium">
-        <button
-          onClick={() => setTab('trips')}
-          className={tab === 'trips' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}
-        >
-          Доступные маршруты
-        </button>
-        <button
-          onClick={() => setTab('create')}
-          className={tab === 'create' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}
-        >
-          Создать поездку
-        </button>
-        <button
-          onClick={() => setTab('requests')}
-          className={tab === 'requests' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}
-        >
-          Заявки
-        </button>
-        <button
-          onClick={() => setTab('mytrips')}
-          className={tab === 'mytrips' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}
-        >
-          Мои поездки
-        </button>
+        <button onClick={() => setTab('list')} className={tab === 'list' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}>Мои посылки</button>
+        <button onClick={() => setTab('create')} className={tab === 'create' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}>Отправить посылку</button>
       </div>
 
-      {/* Содержимое */}
-      <div className="mt-6 max-w-2xl mx-auto">
-        {tab === 'trips' && (
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">Доступные поездки</h2>
-            <ul className="space-y-4">
-              <li className="border rounded p-4 shadow-sm">
-                <p className="font-medium">Казань → Москва · 05.06.2025</p>
-                <p><strong>Водитель:</strong> Иван</p>
-                <p><strong>Рейтинг:</strong> ★ 4.9</p>
-                <p><strong>Цена:</strong> 700 ₽</p>
-                <p><strong>Мест:</strong> 2</p>
-                <button className="mt-2 bg-blue-500 text-white px-3 py-1 rounded">Отправить посылку</button>
-              </li>
-              <li className="border rounded p-4 shadow-sm">
-                <p className="font-medium">Москва → СПб · 06.06.2025</p>
-                <p><strong>Водитель:</strong> Алексей</p>
-                <p><strong>Рейтинг:</strong> ★ 5.0</p>
-                <p><strong>Цена:</strong> 1200 ₽</p>
-                <p><strong>Мест:</strong> 3</p>
-                <button className="mt-2 bg-blue-500 text-white px-3 py-1 rounded">Отправить посылку</button>
-              </li>
-            </ul>
+      <div className="mt-6 max-w-xl mx-auto">
+        {tab === 'list' && (
+          <div>
+            {loading ? (
+              <p>Загрузка...</p>
+            ) : (
+              <ul className="space-y-4">
+                {packages.map(p => (
+                  <li key={p.id} className="border rounded p-4 shadow-sm">
+                    <p className="font-medium">{p.origin} → {p.destination}</p>
+                    <p>Получатель: {p.recipient_name}</p>
+                    <p>Статус: {p.status}</p>
+                    <p>Вес: {p.weight_kg} кг</p>
+                  </li>
+                ))}
+                {packages.length === 0 && <p>Посылок нет</p>}
+              </ul>
+            )}
           </div>
         )}
 
         {tab === 'create' && (
-          <div className="space-y-6">
-            <h2 className="text-xl font-semibold text-center">Создать новую поездку</h2>
-            <form className="grid grid-cols-1 sm:grid-cols-2 gap-4 bg-white border p-6 rounded-lg shadow-md">
-              <div className="col-span-2">
-                <label className="block text-sm font-medium text-gray-700">Откуда</label>
-                <input type="text" placeholder="Город отправления" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div className="col-span-2">
-                <label className="block text-sm font-medium text-gray-700">Куда</label>
-                <input type="text" placeholder="Город назначения" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Дата</label>
-                <input type="date" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Время</label>
-                <input type="time" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Свободные места</label>
-                <input type="number" placeholder="Количество мест" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Цена (₽)</label>
-                <input type="number" placeholder="Стоимость" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div className="col-span-2">
-                <label className="block text-sm font-medium text-gray-700">Описание</label>
-                <textarea placeholder="Комментарий к поездке..." className="w-full mt-1 p-2 border rounded"></textarea>
-              </div>
-              <div className="col-span-2 text-center">
-                <button className="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700 transition">Создать поездку</button>
-              </div>
-            </form>
-          </div>
-        )}
-
-        {tab === 'requests' && (
-          <div className="space-y-6">
+          <form onSubmit={handleCreate} className="space-y-4">
             <div>
-              <h2 className="text-xl font-semibold mb-4 text-center">Отправленные заявки</h2>
-              <ul className="space-y-4">
-                <li className="border p-4 rounded shadow-md">
-                  <p className="font-medium">Вы подали заявку на поездку: СПб → Москва · 06.06.2025</p>
-                  <p className="text-sm text-gray-500">Ожидает одобрения водителя</p>
-                </li>
-                <li className="border p-4 rounded shadow-md">
-                  <p className="font-medium">Вы подали заявку на поездку: Казань → Москва · 07.06.2025</p>
-                  <p className="text-green-600">✅ Заявка одобрена</p>
-                  <div className="mt-3 border-t pt-3">
-                    <h3 className="text-sm font-semibold mb-2">Чат с водителем</h3>
-                    <div className="border p-3 rounded h-40 overflow-y-auto bg-gray-50 text-sm">
-                      <p><strong>Вы:</strong> Добрый день! Можете забрать посылку?</p>
-                      <p><strong>Водитель:</strong> Да, могу после 15:00</p>
-                    </div>
-                    <input
-                      type="text"
-                      placeholder="Написать сообщение..."
-                      className="mt-2 w-full border p-2 rounded"
-                    />
-                  </div>
-                </li>
-              </ul>
+              <label className="block text-sm">Получатель</label>
+              <input name="recipient_name" value={formData.recipient_name} onChange={handleInput} required className="w-full border p-2 rounded" />
             </div>
-          </div>
-        )}
-
-        {tab === 'mytrips' && (
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">Мои поездки</h2>
-            <ul className="space-y-4">
-              <li className="border p-4 rounded shadow">
-                <p className="font-medium">Казань → Москва · 05.06.2025</p>
-                <p><strong>Свободных мест:</strong> 2</p>
-                <p><strong>Цена:</strong> 700 ₽</p>
-                <p><strong>Описание:</strong> Готов взять багаж</p>
-                <button className="mt-2 bg-red-500 text-white px-3 py-1 rounded">Удалить</button>
-                <div className="mt-3">
-                  <h4 className="font-semibold mb-1">Заявки пользователей</h4>
-                  <ul className="space-y-2">
-                    <li className="border p-2 rounded">
-                      Алексей хочет присоединиться к поездке
-                      <div className="flex gap-2 mt-2">
-                        <button className="bg-blue-500 text-white px-3 py-1 rounded">Принять</button>
-                        <button className="bg-gray-300 px-3 py-1 rounded">Отклонить</button>
-                      </div>
-                    </li>
-                  </ul>
-                </div>
-              </li>
-              <li className="border p-4 rounded shadow">
-                <p className="font-medium">Москва → СПб · 06.06.2025</p>
-                <p><strong>Свободных мест:</strong> 1</p>
-                <p><strong>Цена:</strong> 1200 ₽</p>
-                <p><strong>Описание:</strong> Без остановок</p>
-                <button className="mt-2 bg-red-500 text-white px-3 py-1 rounded">Удалить</button>
-              </li>
-            </ul>
-          </div>
+            <div>
+              <label className="block text-sm">Откуда</label>
+              <input name="origin" value={formData.origin} onChange={handleInput} required className="w-full border p-2 rounded" />
+            </div>
+            <div>
+              <label className="block text-sm">Куда</label>
+              <input name="destination" value={formData.destination} onChange={handleInput} required className="w-full border p-2 rounded" />
+            </div>
+            <div>
+              <label className="block text-sm">Вес (кг)</label>
+              <input name="weight_kg" value={formData.weight_kg} onChange={handleInput} required className="w-full border p-2 rounded" />
+            </div>
+            <div>
+              <label className="block text-sm">Цена (₽)</label>
+              <input name="price" value={formData.price} onChange={handleInput} className="w-full border p-2 rounded" />
+            </div>
+            <div>
+              <label className="block text-sm">Дата отправки</label>
+              <input type="date" name="date" value={formData.date} onChange={handleInput} required className="w-full border p-2 rounded" />
+            </div>
+            <div>
+              <label className="block text-sm">Описание</label>
+              <textarea name="description" value={formData.description} onChange={handleInput} className="w-full border p-2 rounded" />
+            </div>
+            <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">Сохранить</button>
+          </form>
         )}
       </div>
     </div>

--- a/rideshare-frontend/src/types/package.ts
+++ b/rideshare-frontend/src/types/package.ts
@@ -1,0 +1,14 @@
+export interface Package {
+  id: number;
+  sender: { id: number; username: string };
+  trip?: number;
+  recipient_name: string;
+  origin: string;
+  destination: string;
+  weight_kg: string;
+  description?: string;
+  price?: string;
+  status: 'pending' | 'assigned' | 'delivered' | 'cancelled';
+  date: string;
+  created_at: string;
+}

--- a/rideshare/urls.py
+++ b/rideshare/urls.py
@@ -31,5 +31,4 @@ urlpatterns = [
     path('api/auth/register/', RegisterView.as_view(), name='token_obtain_pair'),
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    path('api/packages/', include('rideshare_app.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/rideshare_app/serializers.py
+++ b/rideshare_app/serializers.py
@@ -1,5 +1,8 @@
 from rest_framework import serializers
-from .models import User, Trip, Booking, Review, Notification, Message, Complaint, TripReport, Chat, ChatMessage
+from .models import (
+    User, Trip, Booking, Review, Notification, Message, Complaint,
+    TripReport, Chat, ChatMessage, Package
+)
 
 class UserSerializer(serializers.ModelSerializer):
     """
@@ -206,6 +209,19 @@ class ComplaintSerializer(serializers.ModelSerializer):
         validated_data['reported_user'] = reported_user
         validated_data['complainant'] = self.context['request'].user
         return super().create(validated_data)
+
+class PackageSerializer(serializers.ModelSerializer):
+    sender = UserSerializer(read_only=True)
+    trip = TripSerializer(read_only=True)
+
+    class Meta:
+        model = Package
+        fields = [
+            'id', 'sender', 'trip', 'recipient_name', 'origin', 'destination',
+            'weight_kg', 'description', 'price', 'status', 'date',
+            'created_at', 'updated_at'
+        ]
+        read_only_fields = ['status', 'created_at', 'updated_at', 'trip']
 
 class TripReportSerializer(serializers.ModelSerializer):
     class Meta:

--- a/rideshare_app/urls.py
+++ b/rideshare_app/urls.py
@@ -8,6 +8,7 @@ router.register(r'trips', views.TripViewSet)
 router.register(r'bookings', views.BookingViewSet)
 router.register(r'reviews', views.ReviewViewSet)
 router.register(r'complaints', views.ComplaintViewSet)
+router.register(r'packages', views.PackageViewSet)
 router.register(r'chats', views.ChatViewSet)
 router.register(r'reports', views.TripReportViewSet)
 


### PR DESCRIPTION
## Summary
- implement `PackageSerializer`
- add `PackageViewSet` with custom actions
- expose packages endpoints in router and cleanup URL config
- create React page for listing and creating packages
- add `Package` type definitions

## Testing
- `python manage.py test`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b0b700e88321b76adc3a6b229631