### PR TITLE
Implement package sending feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 *.log
 .env
 .DS_Store
+rideshare-frontend/node_modules/
+rideshare-frontend/.next/

--- a/rideshare-frontend/src/app/send-packages/page.tsx
+++ b/rideshare-frontend/src/app/send-packages/page.tsx
@@ -1,168 +1,142 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Trip } from '@/types/trip';
+import { Package } from '@/types/package';
 
-export default function TripControlPage() {
-  const [tab, setTab] = useState<'trips' | 'create' | 'requests' | 'mytrips'>('trips');
+interface PackageForm {
+  trip: string;
+  recipient_name: string;
+  origin: string;
+  destination: string;
+  weight_kg: string;
+  description: string;
+  date: string;
+}
+
+export default function SendPackagesPage() {
+  const router = useRouter();
+  const [trips, setTrips] = useState<Trip[]>([]);
+  const [packages, setPackages] = useState<Package[]>([]);
+  const [form, setForm] = useState<PackageForm>({
+    trip: '',
+    recipient_name: '',
+    origin: '',
+    destination: '',
+    weight_kg: '',
+    description: '',
+    date: ''
+  });
+  const [loading, setLoading] = useState(false);
+  const token = typeof window !== 'undefined' ? localStorage.getItem('access_token') : null;
+
+  useEffect(() => {
+    fetchTrips();
+    fetchPackages();
+  }, []);
+
+  const fetchTrips = async () => {
+    const res = await fetch('http://localhost:8000/api/trips/');
+    if (res.ok) {
+      const data = await res.json();
+      setTrips(data.results || data);
+    }
+  };
+
+  const fetchPackages = async () => {
+    if (!token) return;
+    const res = await fetch('http://localhost:8000/api/packages/', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPackages(data.results || data);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token) {
+      router.push('/auth/login');
+      return;
+    }
+    setLoading(true);
+    const res = await fetch('http://localhost:8000/api/packages/', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        ...form,
+        weight_kg: parseFloat(form.weight_kg)
+      })
+    });
+    setLoading(false);
+    if (res.ok) {
+      setForm({ trip: '', recipient_name: '', origin: '', destination: '', weight_kg: '', description: '', date: '' });
+      fetchPackages();
+    }
+  };
 
   return (
-    <div className="p-4">
-      {/* Меню вкладок */}
-      <div className="flex justify-center gap-8 border-b pb-3 text-sm font-medium">
-        <button
-          onClick={() => setTab('trips')}
-          className={tab === 'trips' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}
-        >
-          Доступные маршруты
+    <div className="max-w-2xl mx-auto p-4 space-y-8">
+      <h1 className="text-xl font-semibold">Отправить посылку</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 border p-4 rounded">
+        <div>
+          <label className="block mb-1 text-sm">Маршрут</label>
+          <select name="trip" value={form.trip} onChange={handleChange} className="w-full border p-2 rounded">
+            <option value="">Выберите поездку</option>
+            {trips.map(trip => (
+              <option key={trip.id} value={trip.id}>{trip.departure_location} → {trip.destination_location}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1 text-sm">Получатель</label>
+          <input name="recipient_name" value={form.recipient_name} onChange={handleChange} className="w-full border p-2 rounded" />
+        </div>
+        <div>
+          <label className="block mb-1 text-sm">Откуда</label>
+          <input name="origin" value={form.origin} onChange={handleChange} className="w-full border p-2 rounded" />
+        </div>
+        <div>
+          <label className="block mb-1 text-sm">Куда</label>
+          <input name="destination" value={form.destination} onChange={handleChange} className="w-full border p-2 rounded" />
+        </div>
+        <div>
+          <label className="block mb-1 text-sm">Вес (кг)</label>
+          <input name="weight_kg" type="number" step="0.1" value={form.weight_kg} onChange={handleChange} className="w-full border p-2 rounded" />
+        </div>
+        <div>
+          <label className="block mb-1 text-sm">Описание</label>
+          <textarea name="description" value={form.description} onChange={handleChange} className="w-full border p-2 rounded" />
+        </div>
+        <div>
+          <label className="block mb-1 text-sm">Дата отправки</label>
+          <input type="date" name="date" value={form.date} onChange={handleChange} className="w-full border p-2 rounded" />
+        </div>
+        <button disabled={loading} className="bg-blue-600 text-white px-4 py-2 rounded">
+          {loading ? 'Отправка...' : 'Отправить'}
         </button>
-        <button
-          onClick={() => setTab('create')}
-          className={tab === 'create' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}
-        >
-          Создать поездку
-        </button>
-        <button
-          onClick={() => setTab('requests')}
-          className={tab === 'requests' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}
-        >
-          Заявки
-        </button>
-        <button
-          onClick={() => setTab('mytrips')}
-          className={tab === 'mytrips' ? 'text-blue-600 border-b-2 border-blue-600' : 'hover:text-blue-500'}
-        >
-          Мои поездки
-        </button>
-      </div>
+      </form>
 
-      {/* Содержимое */}
-      <div className="mt-6 max-w-2xl mx-auto">
-        {tab === 'trips' && (
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">Доступные поездки</h2>
-            <ul className="space-y-4">
-              <li className="border rounded p-4 shadow-sm">
-                <p className="font-medium">Казань → Москва · 05.06.2025</p>
-                <p><strong>Водитель:</strong> Иван</p>
-                <p><strong>Рейтинг:</strong> ★ 4.9</p>
-                <p><strong>Цена:</strong> 700 ₽</p>
-                <p><strong>Мест:</strong> 2</p>
-                <button className="mt-2 bg-blue-500 text-white px-3 py-1 rounded">Отправить посылку</button>
-              </li>
-              <li className="border rounded p-4 shadow-sm">
-                <p className="font-medium">Москва → СПб · 06.06.2025</p>
-                <p><strong>Водитель:</strong> Алексей</p>
-                <p><strong>Рейтинг:</strong> ★ 5.0</p>
-                <p><strong>Цена:</strong> 1200 ₽</p>
-                <p><strong>Мест:</strong> 3</p>
-                <button className="mt-2 bg-blue-500 text-white px-3 py-1 rounded">Отправить посылку</button>
-              </li>
-            </ul>
-          </div>
-        )}
-
-        {tab === 'create' && (
-          <div className="space-y-6">
-            <h2 className="text-xl font-semibold text-center">Создать новую поездку</h2>
-            <form className="grid grid-cols-1 sm:grid-cols-2 gap-4 bg-white border p-6 rounded-lg shadow-md">
-              <div className="col-span-2">
-                <label className="block text-sm font-medium text-gray-700">Откуда</label>
-                <input type="text" placeholder="Город отправления" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div className="col-span-2">
-                <label className="block text-sm font-medium text-gray-700">Куда</label>
-                <input type="text" placeholder="Город назначения" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Дата</label>
-                <input type="date" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Время</label>
-                <input type="time" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Свободные места</label>
-                <input type="number" placeholder="Количество мест" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Цена (₽)</label>
-                <input type="number" placeholder="Стоимость" className="w-full mt-1 p-2 border rounded" />
-              </div>
-              <div className="col-span-2">
-                <label className="block text-sm font-medium text-gray-700">Описание</label>
-                <textarea placeholder="Комментарий к поездке..." className="w-full mt-1 p-2 border rounded"></textarea>
-              </div>
-              <div className="col-span-2 text-center">
-                <button className="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700 transition">Создать поездку</button>
-              </div>
-            </form>
-          </div>
-        )}
-
-        {tab === 'requests' && (
-          <div className="space-y-6">
-            <div>
-              <h2 className="text-xl font-semibold mb-4 text-center">Отправленные заявки</h2>
-              <ul className="space-y-4">
-                <li className="border p-4 rounded shadow-md">
-                  <p className="font-medium">Вы подали заявку на поездку: СПб → Москва · 06.06.2025</p>
-                  <p className="text-sm text-gray-500">Ожидает одобрения водителя</p>
-                </li>
-                <li className="border p-4 rounded shadow-md">
-                  <p className="font-medium">Вы подали заявку на поездку: Казань → Москва · 07.06.2025</p>
-                  <p className="text-green-600">✅ Заявка одобрена</p>
-                  <div className="mt-3 border-t pt-3">
-                    <h3 className="text-sm font-semibold mb-2">Чат с водителем</h3>
-                    <div className="border p-3 rounded h-40 overflow-y-auto bg-gray-50 text-sm">
-                      <p><strong>Вы:</strong> Добрый день! Можете забрать посылку?</p>
-                      <p><strong>Водитель:</strong> Да, могу после 15:00</p>
-                    </div>
-                    <input
-                      type="text"
-                      placeholder="Написать сообщение..."
-                      className="mt-2 w-full border p-2 rounded"
-                    />
-                  </div>
-                </li>
-              </ul>
-            </div>
-          </div>
-        )}
-
-        {tab === 'mytrips' && (
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">Мои поездки</h2>
-            <ul className="space-y-4">
-              <li className="border p-4 rounded shadow">
-                <p className="font-medium">Казань → Москва · 05.06.2025</p>
-                <p><strong>Свободных мест:</strong> 2</p>
-                <p><strong>Цена:</strong> 700 ₽</p>
-                <p><strong>Описание:</strong> Готов взять багаж</p>
-                <button className="mt-2 bg-red-500 text-white px-3 py-1 rounded">Удалить</button>
-                <div className="mt-3">
-                  <h4 className="font-semibold mb-1">Заявки пользователей</h4>
-                  <ul className="space-y-2">
-                    <li className="border p-2 rounded">
-                      Алексей хочет присоединиться к поездке
-                      <div className="flex gap-2 mt-2">
-                        <button className="bg-blue-500 text-white px-3 py-1 rounded">Принять</button>
-                        <button className="bg-gray-300 px-3 py-1 rounded">Отклонить</button>
-                      </div>
-                    </li>
-                  </ul>
-                </div>
-              </li>
-              <li className="border p-4 rounded shadow">
-                <p className="font-medium">Москва → СПб · 06.06.2025</p>
-                <p><strong>Свободных мест:</strong> 1</p>
-                <p><strong>Цена:</strong> 1200 ₽</p>
-                <p><strong>Описание:</strong> Без остановок</p>
-                <button className="mt-2 bg-red-500 text-white px-3 py-1 rounded">Удалить</button>
-              </li>
-            </ul>
-          </div>
-        )}
+      <div>
+        <h2 className="text-lg font-semibold mt-8 mb-2">Мои посылки</h2>
+        <ul className="space-y-2">
+          {packages.map(p => (
+            <li key={p.id} className="border p-3 rounded">
+              <div className="font-medium">{p.origin} → {p.destination} ({p.status})</div>
+              <div className="text-sm text-gray-500">Получатель: {p.recipient_name}</div>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/rideshare-frontend/src/types/package.ts
+++ b/rideshare-frontend/src/types/package.ts
@@ -1,0 +1,18 @@
+export interface Package {
+  id: number;
+  sender: {
+    id: number;
+    username: string;
+  };
+  trip: number | null;
+  recipient_name: string;
+  origin: string;
+  destination: string;
+  weight_kg: number;
+  description?: string;
+  price?: number;
+  status: 'pending' | 'assigned' | 'delivered' | 'cancelled';
+  date: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/rideshare_app/serializers.py
+++ b/rideshare_app/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import User, Trip, Booking, Review, Notification, Message, Complaint, TripReport, Chat, ChatMessage
+from .models import User, Trip, Booking, Review, Notification, Message, Complaint, TripReport, Chat, ChatMessage, Package
 
 class UserSerializer(serializers.ModelSerializer):
     """
@@ -308,3 +308,20 @@ class ChatSerializer(serializers.ModelSerializer):
                 }
             }
         return None
+
+
+class PackageSerializer(serializers.ModelSerializer):
+    """Serializer for the Package model."""
+
+    sender = UserSerializer(read_only=True)
+    trip = TripSerializer(read_only=True)
+
+    class Meta:
+        model = Package
+        fields = '__all__'
+        read_only_fields = (
+            'created_at',
+            'updated_at',
+            'status',
+            'sender',
+        )

--- a/rideshare_app/urls.py
+++ b/rideshare_app/urls.py
@@ -10,6 +10,7 @@ router.register(r'reviews', views.ReviewViewSet)
 router.register(r'complaints', views.ComplaintViewSet)
 router.register(r'chats', views.ChatViewSet)
 router.register(r'reports', views.TripReportViewSet)
+router.register(r'packages', views.PackageViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
## Summary
- ignore frontend build output
- add `PackageSerializer`
- add `PackageViewSet` with assign and deliver actions
- expose packages in API router
- add package types and interactive send-packages page

## Testing
- `python manage.py test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b51c5f7c83219a3a85487fa65670